### PR TITLE
Refactor read operations into query handlers

### DIFF
--- a/src/Action/RobotCollectionAction.php
+++ b/src/Action/RobotCollectionAction.php
@@ -2,18 +2,19 @@
 
 namespace App\Action;
 
-use App\Domain\Service\RobotService;
 use App\Application\DTO\ApiFiltersDTO;
-use Symfony\Component\HttpFoundation\Request;
+use App\Application\Query\GetRobotsQuery;
+use App\Application\Query\Handler\GetRobotsQueryHandler;
 use App\Application\Request\RequestDataMapper;
 use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 
 #[AsController]
 final class RobotCollectionAction
 {
     public function __construct(
-        private RobotService $robotService,
+        private GetRobotsQueryHandler $getRobotsQueryHandler,
         private RequestDataMapper $requestDataMapper,
     ) {
     }
@@ -32,7 +33,8 @@ final class RobotCollectionAction
             itemsPerPage: $request->query->getInt('itemsPerPage', 10)
         );
     
-        $models = $this->robotService->getRobots($apiFiltersDTO);
+        $query = new GetRobotsQuery($apiFiltersDTO);
+        $models = $this->getRobotsQueryHandler->__invoke($query);
 
         return new ArrayCollection($models);
     }

--- a/src/Action/RobotDanceOffsCollectionAction.php
+++ b/src/Action/RobotDanceOffsCollectionAction.php
@@ -3,8 +3,9 @@
 namespace App\Action;
 
 use App\Application\DTO\ApiFiltersDTO;
+use App\Application\Query\GetRobotDanceOffsQuery;
+use App\Application\Query\Handler\GetRobotDanceOffsQueryHandler;
 use App\Application\Request\RequestDataMapper;
-use App\Domain\Service\RobotService;
 use App\Responder\RobotDanceOffResponder;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -13,7 +14,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 final class RobotDanceOffsCollectionAction
 {
     public function __construct(
-        private RobotService $robotService,
+        private GetRobotDanceOffsQueryHandler $getRobotDanceOffsQueryHandler,
         private RequestDataMapper $requestDataMapper,
         private RobotDanceOffResponder $robotDanceOffResponder
     ) {
@@ -34,7 +35,8 @@ final class RobotDanceOffsCollectionAction
             itemsPerPage: $pagination['itemsPerPage']
         );
 
-        $models = $this->robotService->getRobotDanceOffs($apiFiltersDTO);
+        $query = new GetRobotDanceOffsQuery($apiFiltersDTO);
+        $models = $this->getRobotDanceOffsQueryHandler->__invoke($query);
 
         return $this->robotDanceOffResponder->respond($models);
     }

--- a/src/Application/Query/GetRobotDanceOffsQuery.php
+++ b/src/Application/Query/GetRobotDanceOffsQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Query;
+
+use App\Application\DTO\ApiFiltersDTO;
+
+final class GetRobotDanceOffsQuery
+{
+    public function __construct(private readonly ApiFiltersDTO $apiFiltersDTO)
+    {
+    }
+
+    public function getApiFiltersDTO(): ApiFiltersDTO
+    {
+        return $this->apiFiltersDTO;
+    }
+}

--- a/src/Application/Query/GetRobotQuery.php
+++ b/src/Application/Query/GetRobotQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Query;
+
+final class GetRobotQuery
+{
+    public function __construct(private readonly int $robotId)
+    {
+    }
+
+    public function getRobotId(): int
+    {
+        return $this->robotId;
+    }
+}

--- a/src/Application/Query/GetRobotsQuery.php
+++ b/src/Application/Query/GetRobotsQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Query;
+
+use App\Application\DTO\ApiFiltersDTO;
+
+final class GetRobotsQuery
+{
+    public function __construct(private readonly ApiFiltersDTO $apiFiltersDTO)
+    {
+    }
+
+    public function getApiFiltersDTO(): ApiFiltersDTO
+    {
+        return $this->apiFiltersDTO;
+    }
+}

--- a/src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Application\Query\Handler;
+
+use App\Application\Query\GetRobotDanceOffsQuery;
+use App\Domain\Repository\RobotDanceOffRepositoryInterface;
+
+final class GetRobotDanceOffsQueryHandler
+{
+    public function __construct(private readonly RobotDanceOffRepositoryInterface $robotDanceOffRepository)
+    {
+    }
+
+    public function __invoke(GetRobotDanceOffsQuery $query): array
+    {
+        return $this->robotDanceOffRepository->findAll($query->getApiFiltersDTO());
+    }
+}

--- a/src/Application/Query/Handler/GetRobotQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotQueryHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Application\Query\Handler;
+
+use App\Application\Query\GetRobotQuery;
+use App\Domain\Entity\Robot;
+use App\Domain\Repository\RobotRepositoryInterface;
+use App\Domain\Service\RobotValidatorService;
+use RobotServiceException;
+
+final class GetRobotQueryHandler
+{
+    public function __construct(
+        private readonly RobotRepositoryInterface $robotRepository,
+        private readonly RobotValidatorService $robotValidatorService
+    ) {
+    }
+
+    public function __invoke(GetRobotQuery $query): Robot
+    {
+        $robotId = $query->getRobotId();
+        $this->robotValidatorService->validateRobotIds([$robotId]);
+
+        $robot = $this->robotRepository->findOneBy($robotId);
+
+        if ($robot === null) {
+            throw new RobotServiceException(sprintf('Robot ID %d does not exist.', $robotId));
+        }
+
+        return $robot;
+    }
+}

--- a/src/Application/Query/Handler/GetRobotsQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotsQueryHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Application\Query\Handler;
+
+use App\Application\Query\GetRobotsQuery;
+use App\Domain\Repository\RobotRepositoryInterface;
+
+final class GetRobotsQueryHandler
+{
+    public function __construct(private readonly RobotRepositoryInterface $robotRepository)
+    {
+    }
+
+    public function __invoke(GetRobotsQuery $query): array
+    {
+        return $this->robotRepository->findAll($query->getApiFiltersDTO());
+    }
+}


### PR DESCRIPTION
## Summary
- add immutable query DTOs and handlers to encapsulate robot and dance-off lookups
- update robot collection actions to consume the new query handlers
- trim RobotService to command-only responsibilities while keeping dance-off orchestration intact

## Testing
- php -l src/Application/Query/GetRobotsQuery.php src/Application/Query/GetRobotDanceOffsQuery.php src/Application/Query/GetRobotQuery.php src/Application/Query/Handler/GetRobotsQueryHandler.php src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php src/Application/Query/Handler/GetRobotQueryHandler.php src/Action/RobotCollectionAction.php src/Action/RobotDanceOffsCollectionAction.php src/Domain/Service/RobotService.php

------
https://chatgpt.com/codex/tasks/task_e_68d0ae83bc308320a337ae83dc79ae6f