### PR TITLE
Use messenger query bus for robot collections

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,5 +1,6 @@
 framework:
     messenger:
+        default_bus: command.bus
         # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
         # failure_transport: failed
 
@@ -8,6 +9,13 @@ framework:
             # async: '%env(MESSENGER_TRANSPORT_DSN)%'
             # failed: 'doctrine://default?queue_name=failed'
             # sync: 'sync://'
+
+        buses:
+            command.bus: ~
+            query.bus:
+                default_middleware: allow_no_handlers
+                middleware:
+                    - messenger.middleware.handle_message
 
         routing:
             # Route your messages to the transports

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,3 +20,6 @@ services:
 
     App\Infrastructure\Serializer\RobotDanceOffNormalizer:
         tags: ['serializer.normalizer']
+
+    query.bus:
+        alias: 'messenger.bus.query'

--- a/src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php
@@ -4,7 +4,9 @@ namespace App\Application\Query\Handler;
 
 use App\Application\Query\GetRobotDanceOffsQuery;
 use App\Domain\Repository\RobotDanceOffRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler(bus: 'query.bus')]
 final class GetRobotDanceOffsQueryHandler
 {
     public function __construct(private readonly RobotDanceOffRepositoryInterface $robotDanceOffRepository)

--- a/src/Application/Query/Handler/GetRobotQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotQueryHandler.php
@@ -7,7 +7,9 @@ use App\Domain\Entity\Robot;
 use App\Domain\Repository\RobotRepositoryInterface;
 use App\Domain\Service\RobotValidatorService;
 use RobotServiceException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler(bus: 'query.bus')]
 final class GetRobotQueryHandler
 {
     public function __construct(

--- a/src/Application/Query/Handler/GetRobotsQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotsQueryHandler.php
@@ -4,7 +4,9 @@ namespace App\Application\Query\Handler;
 
 use App\Application\Query\GetRobotsQuery;
 use App\Domain\Repository\RobotRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler(bus: 'query.bus')]
 final class GetRobotsQueryHandler
 {
     public function __construct(private readonly RobotRepositoryInterface $robotRepository)


### PR DESCRIPTION
## Summary
- configure the Messenger component with dedicated command and query buses and expose a query bus alias
- dispatch robot collection actions through the query bus and unwrap handler payloads
- tag robot query handlers for the query bus so their results can be retrieved synchronously

## Testing
- php -l src/Action/RobotCollectionAction.php
- php -l src/Action/RobotDanceOffsCollectionAction.php
- php -l src/Application/Query/Handler/GetRobotsQueryHandler.php
- php -l src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php
- php -l src/Application/Query/Handler/GetRobotQueryHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68d0b226a828832083fe58688739816a