### PR TITLE
Fix DoctrineComparisonEnum namespace

### DIFF
--- a/src/Infrastructure/Repository/DoctrineComparisonEnum.php
+++ b/src/Infrastructure/Repository/DoctrineComparisonEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Infrastructure;
+namespace App\Infrastructure\Repository;
 
 use Doctrine\Common\Collections\Expr\Comparison;
 

--- a/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
@@ -5,7 +5,7 @@ namespace App\Infrastructure\Repository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use App\Domain\Entity\RobotDanceOff;
-use App\Infrastructure\DoctrineComparisonEnum;
+use App\Infrastructure\Repository\DoctrineComparisonEnum;
 
 final class RobotDanceOffQueryBuilder
 {

--- a/src/Infrastructure/Repository/RobotQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotQueryBuilder.php
@@ -5,7 +5,7 @@ namespace App\Infrastructure\Repository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use App\Domain\Entity\Robot;
-use App\Infrastructure\DoctrineComparisonEnum;
+use App\Infrastructure\Repository\DoctrineComparisonEnum;
 
 final class RobotQueryBuilder
 {


### PR DESCRIPTION
## Summary
- align `DoctrineComparisonEnum`'s namespace with the `Repository` directory
- update repository query builders to reference the adjusted enum namespace
