### PR TITLE
Configure query bus alias for queries

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,9 @@ services:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
 
+    query.bus:
+        alias: messenger.bus.query
+
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:

--- a/src/Action/RobotCollectionAction.php
+++ b/src/Action/RobotCollectionAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
 final class RobotCollectionAction
 {
     public function __construct(
-        #[Autowire(service: 'command.bus')]
+        #[Autowire(service: 'query.bus')]
         private MessageBusInterface $queryBus,
         private RequestDataMapper $requestDataMapper,
     ) {

--- a/src/Action/RobotDanceOffsCollectionAction.php
+++ b/src/Action/RobotDanceOffsCollectionAction.php
@@ -17,7 +17,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
 final class RobotDanceOffsCollectionAction
 {
     public function __construct(
-        #[Autowire(service: 'command.bus')]
+        #[Autowire(service: 'query.bus')]
         private MessageBusInterface $queryBus,
         private RequestDataMapper $requestDataMapper,
         private RobotDanceOffResponder $robotDanceOffResponder

--- a/src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotDanceOffsQueryHandler.php
@@ -6,7 +6,7 @@ use App\Application\Query\GetRobotDanceOffsQuery;
 use App\Domain\Repository\RobotDanceOffRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler(bus: 'command.bus')]
+#[AsMessageHandler(bus: 'query.bus')]
 final class GetRobotDanceOffsQueryHandler
 {
     public function __construct(private readonly RobotDanceOffRepositoryInterface $robotDanceOffRepository)

--- a/src/Application/Query/Handler/GetRobotQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotQueryHandler.php
@@ -9,7 +9,7 @@ use App\Domain\Service\RobotValidatorService;
 use RobotServiceException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler(bus: 'command.bus')]
+#[AsMessageHandler(bus: 'query.bus')]
 final class GetRobotQueryHandler
 {
     public function __construct(

--- a/src/Application/Query/Handler/GetRobotsQueryHandler.php
+++ b/src/Application/Query/Handler/GetRobotsQueryHandler.php
@@ -6,7 +6,7 @@ use App\Application\Query\GetRobotsQuery;
 use App\Domain\Repository\RobotRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler(bus: 'command.bus')]
+#[AsMessageHandler(bus: 'query.bus')]
 final class GetRobotsQueryHandler
 {
     public function __construct(private readonly RobotRepositoryInterface $robotRepository)


### PR DESCRIPTION
## Summary
- alias the `query.bus` service to `messenger.bus.query` for easier autowiring
- inject the query bus into collection actions via the Autowire attribute
- ensure all query handlers register on the dedicated query bus

## Testing
- php bin/console cache:clear *(fails: Symfony Runtime missing because dependencies are not installed in this environment)*
- composer install *(fails: vimeo/psalm requires PHP <= 8.3 but the container runs PHP 8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bb241f1083209692c642cc8d3bbf