### PR TITLE
Refactor query builders to avoid state leakage

### DIFF
--- a/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
@@ -15,11 +15,20 @@ final class RobotDanceOffQueryBuilder
     private const TEAM_TWO_ALIAS = 'teamTwo';
     private const WINNER_ALIAS = 'winningTeam';
 
-    private QueryBuilder $qb;
+    private ?QueryBuilder $qb = null;
 
     public function __construct(private EntityManagerInterface $entityManager)
     {
-        $this->qb = $entityManager->createQueryBuilder()
+    }
+
+    public function create(): self
+    {
+        return new self($this->entityManager);
+    }
+
+    private function newQueryBuilder(): QueryBuilder
+    {
+        return $this->entityManager->createQueryBuilder()
             ->select(self::ALIAS, self::TEAM_ONE_ALIAS, self::TEAM_TWO_ALIAS, self::WINNER_ALIAS)
             ->from(self::ENTITY, self::ALIAS)
             ->leftJoin(self::ALIAS . '.teamOne', self::TEAM_ONE_ALIAS)
@@ -27,8 +36,26 @@ final class RobotDanceOffQueryBuilder
             ->leftJoin(self::ALIAS . '.winningTeam', self::WINNER_ALIAS);
     }
 
+    private function resetQueryBuilder(): QueryBuilder
+    {
+        $this->qb = $this->newQueryBuilder();
+
+        return $this->qb;
+    }
+
+    private function getInitializedQueryBuilder(): QueryBuilder
+    {
+        if ($this->qb === null) {
+            throw new \LogicException('Query builder must be initialised before building the query.');
+        }
+
+        return $this->qb;
+    }
+
     public function whereClauses(array $filters, array $operations): self
     {
+        $qb = $this->resetQueryBuilder();
+
         foreach ($filters as $filter => $value) {
             $operation = $operations[$filter] ?? DoctrineComparisonEnum::eq->value;
 
@@ -36,36 +63,38 @@ final class RobotDanceOffQueryBuilder
                 throw new \InvalidArgumentException("Invalid operation: $operation");
             }
 
-            // ✅ Self-references for alias
-            $this->qb->andWhere(self::ALIAS . ".$filter $operation :$filter")
-                     ->setParameter($filter, $value);
+            $qb->andWhere(self::ALIAS . ".$filter $operation :$filter")
+               ->setParameter($filter, $value);
         }
         return $this;
     }
 
     public function addSorts(array $sorts): self
     {
+        $qb = $this->getInitializedQueryBuilder();
+
         foreach ($sorts as $field => $order) {
-            $this->qb->addOrderBy(self::ALIAS . ".$field", $order);
+            $qb->addOrderBy(self::ALIAS . ".$field", $order);
         }
         return $this;
     }
 
     public function paginate(int $page, int $itemsPerPage): self
     {
-        $this->qb->setFirstResult(($page - 1) * $itemsPerPage)
-                 ->setMaxResults($itemsPerPage);
+        $qb = $this->getInitializedQueryBuilder();
+
+        $qb->setFirstResult(($page - 1) * $itemsPerPage)
+           ->setMaxResults($itemsPerPage);
 
         return $this;
     }
 
     public function fetchArray(): array
     {
-        return $this->qb->getQuery()->getResult();
-    }
+        $qb = $this->getInitializedQueryBuilder();
+        $results = $qb->getQuery()->getResult();
+        $this->qb = null;
 
-    public function createQueryBuilder(): QueryBuilder
-    {
-        return $this->qb;
+        return $results;
     }
 }

--- a/src/Infrastructure/Repository/RobotDanceOffRepository.php
+++ b/src/Infrastructure/Repository/RobotDanceOffRepository.php
@@ -19,7 +19,9 @@ final class RobotDanceOffRepository implements RobotDanceOffRepositoryInterface
      */
     public function findAll(ApiFiltersDTO $apiFiltersDTO): array
     {
-        return $this->robotDanceOffQueryBuilder
+        $queryBuilder = $this->robotDanceOffQueryBuilder->create();
+
+        return $queryBuilder
             ->whereClauses(
                 $apiFiltersDTO->getFilters(),
                 $apiFiltersDTO->getOperations()

--- a/src/Infrastructure/Repository/RobotRepository.php
+++ b/src/Infrastructure/Repository/RobotRepository.php
@@ -18,7 +18,9 @@ final class RobotRepository implements RobotRepositoryInterface
      */
     public function findAll(ApiFiltersDTO $apiFiltersDTO): array
     {
-        return $this->robotQueryBuilder
+        $queryBuilder = $this->robotQueryBuilder->create();
+
+        return $queryBuilder
             ->whereClauses(
                 $apiFiltersDTO->getFilters(),
                 $apiFiltersDTO->getOperations()
@@ -45,7 +47,9 @@ final class RobotRepository implements RobotRepositoryInterface
      */
     public function findOneBy(int $id): ?Robot
     {
-        return $this->robotQueryBuilder
+        $queryBuilder = $this->robotQueryBuilder->create();
+
+        return $queryBuilder
             ->whereId($id)
             ->fetchOne();
     }

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TestBootstrap.php';
+
+use App\Application\DTO\ApiFiltersDTO;
+use App\Domain\Entity\Robot;
+use App\Domain\Entity\RobotDanceOff;
+use App\Infrastructure\Repository\RobotDanceOffQueryBuilder;
+use App\Infrastructure\Repository\RobotDanceOffRepository;
+use App\Infrastructure\Repository\RobotQueryBuilder;
+use App\Infrastructure\Repository\RobotRepository;
+use Tests\Stub\FakeDoctrineRepository;
+use Tests\Stub\FakeEntityManager;
+
+function assertTrue(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+$datasets = [
+    Robot::class => [
+        ['id' => 1, 'name' => 'Alpha', 'experience' => 10, 'outOfOrder' => false],
+        ['id' => 2, 'name' => 'Beta', 'experience' => 4, 'outOfOrder' => true],
+        ['id' => 3, 'name' => 'Gamma', 'experience' => 7, 'outOfOrder' => false],
+    ],
+    RobotDanceOff::class => [
+        ['id' => 1, 'title' => 'Qualifier', 'winningTeam' => 'Team One'],
+        ['id' => 2, 'title' => 'Final', 'winningTeam' => 'Team Two'],
+    ],
+];
+
+$entityManager = new FakeEntityManager($datasets);
+
+$robotRepository = new RobotRepository(
+    new RobotQueryBuilder($entityManager),
+    new FakeDoctrineRepository()
+);
+
+$firstRobots = $robotRepository->findAll(new ApiFiltersDTO(
+    ['outOfOrder' => false],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($firstRobots) === 2, 'First robot query should return two robots.');
+
+$secondRobots = $robotRepository->findAll(new ApiFiltersDTO(
+    ['outOfOrder' => true],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($secondRobots) === 1, 'Second robot query should return one robot.');
+assertTrue($secondRobots[0]['name'] === 'Beta', 'Filtered robot should be Beta.');
+
+$robot = $robotRepository->findOneBy(3);
+assertTrue($robot !== null && $robot->getName() === 'Gamma', 'findOneBy should return Gamma robot.');
+assertTrue($robot->getExperience() === 7, 'findOneBy should hydrate experience property.');
+
+$robotDanceOffRepository = new RobotDanceOffRepository(
+    $entityManager,
+    new RobotDanceOffQueryBuilder($entityManager)
+);
+
+$firstDance = $robotDanceOffRepository->findAll(new ApiFiltersDTO(
+    ['id' => 1],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($firstDance) === 1 && $firstDance[0]['id'] === 1, 'First dance-off query should return ID 1.');
+
+$secondDance = $robotDanceOffRepository->findAll(new ApiFiltersDTO(
+    ['id' => 2],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($secondDance) === 1 && $secondDance[0]['id'] === 2, 'Second dance-off query should return ID 2.');
+
+echo "Repository tests completed successfully.\n";

--- a/tests/Stubs/DoctrineCollectionsStubs.php
+++ b/tests/Stubs/DoctrineCollectionsStubs.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Collections;
+
+interface Collection
+{
+    public function contains(mixed $element): bool;
+
+    public function add(mixed $element): void;
+
+    public function removeElement(mixed $element): void;
+}
+
+final class ArrayCollection implements Collection
+{
+    /** @var array<int, mixed> */
+    private array $elements;
+
+    public function __construct(array $elements = [])
+    {
+        $this->elements = array_values($elements);
+    }
+
+    public function contains(mixed $element): bool
+    {
+        return in_array($element, $this->elements, true);
+    }
+
+    public function add(mixed $element): void
+    {
+        if (!$this->contains($element)) {
+            $this->elements[] = $element;
+        }
+    }
+
+    public function removeElement(mixed $element): void
+    {
+        $this->elements = array_values(
+            array_filter(
+                $this->elements,
+                static fn (mixed $existing): bool => $existing !== $element
+            )
+        );
+    }
+}

--- a/tests/Stubs/DoctrineComparisonStubs.php
+++ b/tests/Stubs/DoctrineComparisonStubs.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Collections\Expr;
+
+final class Comparison
+{
+    public const EQ = '=';
+    public const NEQ = '!=';
+    public const GT = '>';
+    public const GTE = '>=';
+    public const LT = '<';
+    public const LTE = '<=';
+    public const CONTAINS = 'LIKE';
+    public const IN = 'IN';
+}

--- a/tests/Stubs/DoctrineMappingStubs.php
+++ b/tests/Stubs/DoctrineMappingStubs.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Entity
+{
+    public function __construct(public ?string $repositoryClass = null)
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Table
+{
+    public function __construct(public ?string $name = null)
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Id
+{
+    public function __construct()
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class GeneratedValue
+{
+    public function __construct()
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Column
+{
+    public function __construct(
+        public ?string $type = null,
+        public ?int $length = null,
+        public bool $nullable = false
+    ) {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ManyToMany
+{
+    public function __construct(
+        public ?string $mappedBy = null,
+        public ?string $targetEntity = null
+    ) {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class JoinTable
+{
+    public function __construct(public ?string $name = null)
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ManyToOne
+{
+    public function __construct(
+        public ?string $targetEntity = null,
+        public array $cascade = []
+    ) {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class JoinColumn
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $referencedColumnName = null,
+        public bool $nullable = true
+    ) {
+    }
+}

--- a/tests/Stubs/DoctrineOrmStubs.php
+++ b/tests/Stubs/DoctrineOrmStubs.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM;
+
+final class Query
+{
+    /**
+     * @param array<int, array<string, mixed>|object> $results
+     */
+    public function __construct(private array $results, private ?string $entityClass = null)
+    {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getArrayResult(): array
+    {
+        return array_map([$this, 'normalize'], $this->results);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getResult(): array
+    {
+        return $this->getArrayResult();
+    }
+
+    public function getOneOrNullResult(): ?object
+    {
+        if ($this->results === []) {
+            return null;
+        }
+
+        $first = $this->results[0];
+
+        if (is_object($first)) {
+            return $first;
+        }
+
+        if ($this->entityClass === null || !class_exists($this->entityClass)) {
+            return (object) $first;
+        }
+
+        return $this->hydrateEntity($first);
+    }
+
+    /**
+     * @param array<string, mixed>|object $row
+     * @return array<string, mixed>
+     */
+    private function normalize(array|object $row): array
+    {
+        if (is_array($row)) {
+            return $row;
+        }
+
+        $data = [];
+        $reflection = new \ReflectionObject($row);
+        foreach ($reflection->getProperties() as $property) {
+            $property->setAccessible(true);
+            $data[$property->getName()] = $property->getValue($row);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrateEntity(array $row): object
+    {
+        $entityClass = $this->entityClass;
+        $entity = new $entityClass();
+
+        foreach ($row as $field => $value) {
+            $method = 'set' . ucfirst($field);
+            if (method_exists($entity, $method)) {
+                $entity->$method($value);
+                continue;
+            }
+
+            $this->setProperty($entity, $field, $value);
+        }
+
+        return $entity;
+    }
+
+    private function setProperty(object $entity, string $field, mixed $value): void
+    {
+        $reflection = new \ReflectionObject($entity);
+        if (!$reflection->hasProperty($field)) {
+            return;
+        }
+
+        $property = $reflection->getProperty($field);
+        $property->setAccessible(true);
+        $property->setValue($entity, $value);
+    }
+}
+
+interface EntityManagerInterface
+{
+    public function createQueryBuilder(): QueryBuilder;
+
+    public function persist(object $entity): void;
+
+    public function flush(): void;
+
+    public function remove(object $entity): void;
+
+    public function getRepository(string $className): object;
+}
+
+final class QueryBuilder
+{
+    private ?string $entityClass = null;
+
+    private ?string $alias = null;
+
+    /** @var array<string, mixed> */
+    private array $parameters = [];
+
+    /** @var array<int, array{field: string, operator: string, parameter: string}> */
+    private array $conditions = [];
+
+    /** @var array<int, array{field: string, direction: string}> */
+    private array $orderBy = [];
+
+    private ?int $firstResult = null;
+
+    private ?int $maxResults = null;
+
+    /** @var array<int, array<string, mixed>> */
+    private array $data = [];
+
+    /** @param array<class-string, array<int, array<string, mixed>>> $datasets */
+    public function __construct(private array $datasets = [])
+    {
+    }
+
+    public function select(string ...$select): self
+    {
+        return $this;
+    }
+
+    public function from(string $entityClass, string $alias): self
+    {
+        $this->entityClass = $entityClass;
+        $this->alias = $alias;
+        $this->data = $this->datasets[$entityClass] ?? [];
+
+        return $this;
+    }
+
+    public function leftJoin(string $from, string $alias, ?string $conditionType = null, ?string $condition = null): self
+    {
+        return $this;
+    }
+
+    public function andWhere(string $condition): self
+    {
+        $pattern = '/^([a-zA-Z0-9_\.]+)\s*(=|!=|>=|<=|>|<|LIKE|IN)\s*:(\w+)$/';
+        if (!preg_match($pattern, $condition, $matches)) {
+            throw new \InvalidArgumentException(sprintf('Unsupported condition "%s".', $condition));
+        }
+
+        $this->conditions[] = [
+            'field' => $matches[1],
+            'operator' => strtoupper($matches[2]),
+            'parameter' => $matches[3],
+        ];
+
+        return $this;
+    }
+
+    public function setParameter(string $name, mixed $value): self
+    {
+        $this->parameters[$name] = $value;
+
+        return $this;
+    }
+
+    public function addOrderBy(string $field, string $direction): self
+    {
+        $this->orderBy[] = [
+            'field' => $field,
+            'direction' => strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC',
+        ];
+
+        return $this;
+    }
+
+    public function setFirstResult(int $firstResult): self
+    {
+        $this->firstResult = max(0, $firstResult);
+
+        return $this;
+    }
+
+    public function setMaxResults(int $maxResults): self
+    {
+        $this->maxResults = $maxResults >= 0 ? $maxResults : null;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getRootAliases(): array
+    {
+        return $this->alias !== null ? [$this->alias] : [];
+    }
+
+    public function getQuery(): Query
+    {
+        $results = $this->applyConditions($this->data);
+        $results = $this->applySorting($results);
+        $results = $this->applyPagination($results);
+
+        return new Query($results, $this->entityClass);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $dataset
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyConditions(array $dataset): array
+    {
+        if ($this->conditions === []) {
+            return $dataset;
+        }
+
+        return array_values(array_filter(
+            $dataset,
+            function (array $row): bool {
+                foreach ($this->conditions as $condition) {
+                    $field = $this->extractField($condition['field']);
+                    $value = $row[$field] ?? null;
+                    $parameter = $this->parameters[$condition['parameter']] ?? null;
+
+                    if (!$this->compare($value, $parameter, $condition['operator'])) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        ));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $dataset
+     * @return array<int, array<string, mixed>>
+     */
+    private function applySorting(array $dataset): array
+    {
+        if ($this->orderBy === []) {
+            return $dataset;
+        }
+
+        usort(
+            $dataset,
+            function (array $left, array $right): int {
+                foreach ($this->orderBy as $order) {
+                    $field = $this->extractField($order['field']);
+                    $leftValue = $left[$field] ?? null;
+                    $rightValue = $right[$field] ?? null;
+
+                    if ($leftValue === $rightValue) {
+                        continue;
+                    }
+
+                    $comparison = $leftValue <=> $rightValue;
+                    if ($order['direction'] === 'DESC') {
+                        $comparison *= -1;
+                    }
+
+                    if ($comparison !== 0) {
+                        return $comparison;
+                    }
+                }
+
+                return 0;
+            }
+        );
+
+        return $dataset;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $dataset
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyPagination(array $dataset): array
+    {
+        if ($this->firstResult === null && $this->maxResults === null) {
+            return $dataset;
+        }
+
+        $offset = $this->firstResult ?? 0;
+        $length = $this->maxResults ?? null;
+
+        return array_slice($dataset, $offset, $length);
+    }
+
+    private function extractField(string $expression): string
+    {
+        $parts = explode('.', $expression);
+
+        return (string) end($parts);
+    }
+
+    private function compare(mixed $fieldValue, mixed $parameterValue, string $operator): bool
+    {
+        $operator = strtoupper($operator);
+
+        return match ($operator) {
+            '=', 'EQ' => $fieldValue == $parameterValue,
+            '!=', '<>' => $fieldValue != $parameterValue,
+            '>', 'GT' => $fieldValue > $parameterValue,
+            '>=', 'GTE' => $fieldValue >= $parameterValue,
+            '<', 'LT' => $fieldValue < $parameterValue,
+            '<=', 'LTE' => $fieldValue <= $parameterValue,
+            'LIKE' => $this->compareLike($fieldValue, $parameterValue),
+            'IN' => in_array($fieldValue, (array) $parameterValue, true),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported operator "%s".', $operator)),
+        };
+    }
+
+    private function compareLike(mixed $fieldValue, mixed $parameterValue): bool
+    {
+        $needle = is_string($parameterValue) ? trim($parameterValue, '%') : '';
+
+        return is_string($fieldValue) && str_contains(strtolower($fieldValue), strtolower($needle));
+    }
+}

--- a/tests/Stubs/FakeDoctrineRepository.php
+++ b/tests/Stubs/FakeDoctrineRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub;
+
+use App\Infrastructure\Repository\DoctrineRepositoryInterface;
+
+final class FakeDoctrineRepository implements DoctrineRepositoryInterface
+{
+    public function createQueryBuilder(string $entityClass, string $entityAlias): self
+    {
+        return $this;
+    }
+
+    public function whereEqual(string $field, mixed $value): self
+    {
+        return $this;
+    }
+
+    public function whereLike(string $field, mixed $value): self
+    {
+        return $this;
+    }
+
+    public function buildSorts(array $sorts): self
+    {
+        return $this;
+    }
+
+    public function buildPagination(int $page, int $itemsPerPage): self
+    {
+        return $this;
+    }
+
+    public function fetchArray(): array
+    {
+        return [];
+    }
+
+    public function findOne(): ?object
+    {
+        return null;
+    }
+
+    public function persist(object $entity): void
+    {
+    }
+
+    public function save(): void
+    {
+    }
+
+    public function remove(object $entity): void
+    {
+    }
+}

--- a/tests/Stubs/FakeEntityManager.php
+++ b/tests/Stubs/FakeEntityManager.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final class FakeEntityManager implements EntityManagerInterface
+{
+    /**
+     * @param array<class-string, array<int, array<string, mixed>>> $datasets
+     */
+    public function __construct(private array $datasets)
+    {
+    }
+
+    public function createQueryBuilder(): QueryBuilder
+    {
+        return new QueryBuilder($this->datasets);
+    }
+
+    public function persist(object $entity): void
+    {
+    }
+
+    public function flush(): void
+    {
+    }
+
+    public function remove(object $entity): void
+    {
+    }
+
+    public function getRepository(string $className): object
+    {
+        return new FakeObjectRepository($this->datasets[$className] ?? []);
+    }
+}

--- a/tests/Stubs/FakeObjectRepository.php
+++ b/tests/Stubs/FakeObjectRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub;
+
+final class FakeObjectRepository
+{
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     */
+    public function __construct(private array $rows)
+    {
+    }
+
+    public function find(int $id): ?object
+    {
+        foreach ($this->rows as $row) {
+            if (($row['id'] ?? null) === $id) {
+                return (object) $row;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/TestBootstrap.php
+++ b/tests/TestBootstrap.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Stubs/DoctrineMappingStubs.php';
+require_once __DIR__ . '/Stubs/DoctrineCollectionsStubs.php';
+require_once __DIR__ . '/Stubs/DoctrineComparisonStubs.php';
+require_once __DIR__ . '/Stubs/DoctrineOrmStubs.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../src/';
+
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relativeClass = substr($class, strlen($prefix));
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
+// Handle classes that live outside of the PSR-4 directory expectations in this
+// lightweight test environment.
+require_once __DIR__ . '/../src/Infrastructure/Repository/DoctrineComparisonEnum.php';
+
+require_once __DIR__ . '/Stubs/FakeEntityManager.php';
+require_once __DIR__ . '/Stubs/FakeObjectRepository.php';
+require_once __DIR__ . '/Stubs/FakeDoctrineRepository.php';


### PR DESCRIPTION
## Summary
- rework RobotQueryBuilder and RobotDanceOffQueryBuilder to spin up fresh Doctrine query builders for each invocation
- update RobotRepository and RobotDanceOffRepository to request new builders per query chain
- add lightweight Doctrine stubs and repository tests covering repeated queries with different filters

## Testing
- php tests/Repository/RepositoryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d0bb9667d48320815e9f61fe713031