### PR TITLE
Add safe comparison validation for repositories

### DIFF
--- a/src/Infrastructure/Repository/DoctrineComparisonFilterTrait.php
+++ b/src/Infrastructure/Repository/DoctrineComparisonFilterTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Infrastructure\Repository;
+
+use App\Infrastructure\DoctrineComparisonEnum;
+use Doctrine\ORM\QueryBuilder;
+use InvalidArgumentException;
+use ValueError;
+
+trait DoctrineComparisonFilterTrait
+{
+    /**
+     * @param array<string, mixed> $filters
+     * @param array<string, string> $operations
+     */
+    private function applyFilters(QueryBuilder $queryBuilder, array $filters, array $operations, string $alias): void
+    {
+        foreach ($filters as $field => $value) {
+            $operation = $this->normalizeOperation($operations[$field] ?? null);
+
+            $queryBuilder
+                ->andWhere(sprintf('%s.%s %s :%s', $alias, $field, $operation, $field))
+                ->setParameter($field, $value);
+        }
+    }
+
+    private function normalizeOperation(?string $operation): string
+    {
+        if ($operation === null) {
+            return DoctrineComparisonEnum::eq->value;
+        }
+
+        $comparison = DoctrineComparisonEnum::tryFrom($operation);
+
+        if ($comparison instanceof DoctrineComparisonEnum) {
+            return $comparison->value;
+        }
+
+        try {
+            return DoctrineComparisonEnum::fromName($operation);
+        } catch (ValueError $exception) {
+            throw new InvalidArgumentException(sprintf('Invalid operation: %s', $operation), 0, $exception);
+        }
+    }
+}

--- a/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
@@ -5,10 +5,11 @@ namespace App\Infrastructure\Repository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use App\Domain\Entity\RobotDanceOff;
-use App\Infrastructure\DoctrineComparisonEnum;
 
 final class RobotDanceOffQueryBuilder
 {
+    use DoctrineComparisonFilterTrait;
+
     private const ENTITY = RobotDanceOff::class;
     private const ALIAS = 'rdo';
     private const TEAM_ONE_ALIAS = 'teamOne';
@@ -29,17 +30,8 @@ final class RobotDanceOffQueryBuilder
 
     public function whereClauses(array $filters, array $operations): self
     {
-        foreach ($filters as $filter => $value) {
-            $operation = $operations[$filter] ?? DoctrineComparisonEnum::eq->value;
+        $this->applyFilters($this->qb, $filters, $operations, self::ALIAS);
 
-            if (!DoctrineComparisonEnum::tryFrom($operation)) {
-                throw new \InvalidArgumentException("Invalid operation: $operation");
-            }
-
-            // ✅ Self-references for alias
-            $this->qb->andWhere(self::ALIAS . ".$filter $operation :$filter")
-                     ->setParameter($filter, $value);
-        }
         return $this;
     }
 

--- a/src/Infrastructure/Repository/RobotQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotQueryBuilder.php
@@ -5,10 +5,11 @@ namespace App\Infrastructure\Repository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use App\Domain\Entity\Robot;
-use App\Infrastructure\DoctrineComparisonEnum;
 
 final class RobotQueryBuilder
 {
+    use DoctrineComparisonFilterTrait;
+
     private const ENTITY = Robot::class;
     private const ALIAS = 'r';
 
@@ -37,16 +38,8 @@ final class RobotQueryBuilder
      */
     public function whereClauses(array $filters, array $operations): self
     {
-        foreach ($filters as $filter => $value) {
-            $operation = $operations[$filter] ?? DoctrineComparisonEnum::eq->value;
+        $this->applyFilters($this->qb, $filters, $operations, self::ALIAS);
 
-            if (!DoctrineComparisonEnum::tryFrom($operation)) {
-                throw new \InvalidArgumentException("Invalid operation: $operation");
-            }
-
-            $this->qb->andWhere(self::ALIAS . ".$filter $operation :$filter")
-                     ->setParameter($filter, $value);
-        }
         return $this;
     }
 

--- a/src/Infrastructure/Repository/TeamRepository.php
+++ b/src/Infrastructure/Repository/TeamRepository.php
@@ -5,11 +5,12 @@ namespace App\Infrastructure\Repository;
 use App\Domain\Entity\Team;
 use App\Domain\Repository\TeamRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\QueryBuilder;
 use App\Application\DTO\ApiFiltersDTO;
 
 class TeamRepository implements TeamRepositoryInterface
 {
+    use DoctrineComparisonFilterTrait;
+
     public function __construct(
         private EntityManagerInterface $entityManager
     ) {}
@@ -31,11 +32,12 @@ class TeamRepository implements TeamRepositoryInterface
             ->select('t')
             ->from(Team::class, 't');
 
-        foreach ($apiFiltersDTO->getFilters() as $filter => $value) {
-            $operator = $apiFiltersDTO->getOperations()[$filter] ?? '=';
-            $qb->andWhere("t.$filter $operator :$filter")
-               ->setParameter($filter, $value);
-        }
+        $this->applyFilters(
+            $qb,
+            $apiFiltersDTO->getFilters(),
+            $apiFiltersDTO->getOperations(),
+            't'
+        );
 
         foreach ($apiFiltersDTO->getSorts() as $field => $order) {
             $qb->addOrderBy("t.$field", $order);

--- a/tests/Infrastructure/Repository/TeamRepositoryTest.php
+++ b/tests/Infrastructure/Repository/TeamRepositoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Tests\Infrastructure\Repository;
+
+use App\Application\DTO\ApiFiltersDTO;
+use App\Domain\Entity\Team;
+use App\Infrastructure\Repository\TeamRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class TeamRepositoryTest extends TestCase
+{
+    public function testFindAllThrowsWhenOperatorIsNotAllowed(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $entityManager
+            ->expects(self::once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $queryBuilder
+            ->expects(self::once())
+            ->method('select')
+            ->with('t')
+            ->willReturnSelf();
+
+        $queryBuilder
+            ->expects(self::once())
+            ->method('from')
+            ->with(Team::class, 't')
+            ->willReturnSelf();
+
+        $queryBuilder->expects(self::never())->method('andWhere');
+        $queryBuilder->expects(self::never())->method('setParameter');
+
+        $apiFilters = new ApiFiltersDTO(
+            filters: ['name' => 'Team Rocket'],
+            operations: ['name' => 'INVALID'],
+            sorts: [],
+            page: 1,
+            itemsPerPage: 10
+        );
+
+        $repository = new TeamRepository($entityManager);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid operation: INVALID');
+
+        $repository->findAll($apiFilters);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable DoctrineComparisonFilterTrait to centralize operator validation
- update TeamRepository, RobotQueryBuilder, and RobotDanceOffQueryBuilder to use the shared validation when applying filters
- cover invalid operator handling with a unit test for TeamRepository

## Testing
- composer install --ignore-platform-reqs *(fails: GitHub zip downloads are blocked by proxy/403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bb9f977c8320b90f0e7562883268