### PR TITLE
Introduce reusable Doctrine query builder base and fix filters

### DIFF
--- a/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
+++ b/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Infrastructure\Repository;
+
+use App\Infrastructure\DoctrineComparisonEnum;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+
+abstract class AbstractDoctrineQueryBuilder
+{
+    private ?QueryBuilder $qb = null;
+
+    public function __construct(protected EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function create(): static
+    {
+        $builder = new static($this->entityManager);
+        $builder->resetQueryBuilder();
+
+        return $builder;
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @param array<string, string> $operations
+     */
+    public function whereClauses(array $filters, array $operations): static
+    {
+        $qb = $this->getQueryBuilder();
+
+        foreach ($filters as $field => $value) {
+            $operator = $this->resolveOperator($operations[$field] ?? null);
+            $parameter = $this->normalizeParameterName($field);
+
+            $qb->andWhere(sprintf('%s.%s %s :%s', $this->alias(), $field, $operator, $parameter))
+               ->setParameter($parameter, $this->prepareValue($operator, $value));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, string> $sorts
+     */
+    public function addSorts(array $sorts): static
+    {
+        $qb = $this->getQueryBuilder();
+
+        foreach ($sorts as $field => $direction) {
+            $qb->addOrderBy(sprintf('%s.%s', $this->alias(), $field), $direction);
+        }
+
+        return $this;
+    }
+
+    public function paginate(int $page, int $itemsPerPage): static
+    {
+        $qb = $this->getQueryBuilder();
+        $qb->setFirstResult(($page - 1) * $itemsPerPage)
+           ->setMaxResults($itemsPerPage);
+
+        return $this;
+    }
+
+    protected function fetchArrayResult(): array
+    {
+        $qb = $this->getQueryBuilder();
+        $results = $qb->getQuery()->getArrayResult();
+        $this->clearQueryBuilder();
+
+        return $results;
+    }
+
+    protected function fetchOneResult(): ?object
+    {
+        $qb = $this->getQueryBuilder();
+        $result = $qb->getQuery()->getOneOrNullResult();
+        $this->clearQueryBuilder();
+
+        return $result;
+    }
+
+    protected function getQueryBuilder(): QueryBuilder
+    {
+        if ($this->qb === null) {
+            $this->qb = $this->buildBaseQueryBuilder();
+            $this->applyDefaultFilters($this->qb);
+        }
+
+        return $this->qb;
+    }
+
+    protected function resetQueryBuilder(): QueryBuilder
+    {
+        $this->clearQueryBuilder();
+
+        return $this->getQueryBuilder();
+    }
+
+    protected function clearQueryBuilder(): void
+    {
+        $this->qb = null;
+    }
+
+    abstract protected function buildBaseQueryBuilder(): QueryBuilder;
+
+    protected function applyDefaultFilters(QueryBuilder $qb): void
+    {
+        // Intentionally left blank for subclasses to override when needed.
+    }
+
+    abstract protected function alias(): string;
+
+    private function resolveOperator(?string $operation): string
+    {
+        if ($operation === null) {
+            return DoctrineComparisonEnum::eq->value;
+        }
+
+        if (($enum = DoctrineComparisonEnum::tryFrom($operation)) !== null) {
+            return $this->normalizeOperator($enum->value);
+        }
+
+        try {
+            $value = DoctrineComparisonEnum::fromName($operation);
+        } catch (\ValueError $exception) {
+            throw new \InvalidArgumentException("Invalid operation: $operation", 0, $exception);
+        }
+
+        return $this->normalizeOperator($value);
+    }
+
+    private function normalizeOperator(string $operator): string
+    {
+        return match ($operator) {
+            Comparison::CONTAINS => 'LIKE',
+            default => $operator,
+        };
+    }
+
+    private function prepareValue(string $operator, mixed $value): mixed
+    {
+        return match (strtoupper($operator)) {
+            'LIKE' => sprintf('%%%s%%', $value),
+            default => $value,
+        };
+    }
+
+    private function normalizeParameterName(string $field): string
+    {
+        return str_replace('.', '_', $field);
+    }
+}

--- a/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
@@ -2,12 +2,10 @@
 
 namespace App\Infrastructure\Repository;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\QueryBuilder;
 use App\Domain\Entity\RobotDanceOff;
-use App\Infrastructure\DoctrineComparisonEnum;
+use Doctrine\ORM\QueryBuilder;
 
-final class RobotDanceOffQueryBuilder
+final class RobotDanceOffQueryBuilder extends AbstractDoctrineQueryBuilder
 {
     private const ENTITY = RobotDanceOff::class;
     private const ALIAS = 'rdo';
@@ -15,11 +13,18 @@ final class RobotDanceOffQueryBuilder
     private const TEAM_TWO_ALIAS = 'teamTwo';
     private const WINNER_ALIAS = 'winningTeam';
 
-    private QueryBuilder $qb;
-
-    public function __construct(private EntityManagerInterface $entityManager)
+    public function fetchArray(): array
     {
-        $this->qb = $entityManager->createQueryBuilder()
+        $qb = $this->getQueryBuilder();
+        $results = $qb->getQuery()->getResult();
+        $this->clearQueryBuilder();
+
+        return $results;
+    }
+
+    protected function buildBaseQueryBuilder(): QueryBuilder
+    {
+        return $this->entityManager->createQueryBuilder()
             ->select(self::ALIAS, self::TEAM_ONE_ALIAS, self::TEAM_TWO_ALIAS, self::WINNER_ALIAS)
             ->from(self::ENTITY, self::ALIAS)
             ->leftJoin(self::ALIAS . '.teamOne', self::TEAM_ONE_ALIAS)
@@ -27,45 +32,8 @@ final class RobotDanceOffQueryBuilder
             ->leftJoin(self::ALIAS . '.winningTeam', self::WINNER_ALIAS);
     }
 
-    public function whereClauses(array $filters, array $operations): self
+    protected function alias(): string
     {
-        foreach ($filters as $filter => $value) {
-            $operation = $operations[$filter] ?? DoctrineComparisonEnum::eq->value;
-
-            if (!DoctrineComparisonEnum::tryFrom($operation)) {
-                throw new \InvalidArgumentException("Invalid operation: $operation");
-            }
-
-            // ✅ Self-references for alias
-            $this->qb->andWhere(self::ALIAS . ".$filter $operation :$filter")
-                     ->setParameter($filter, $value);
-        }
-        return $this;
-    }
-
-    public function addSorts(array $sorts): self
-    {
-        foreach ($sorts as $field => $order) {
-            $this->qb->addOrderBy(self::ALIAS . ".$field", $order);
-        }
-        return $this;
-    }
-
-    public function paginate(int $page, int $itemsPerPage): self
-    {
-        $this->qb->setFirstResult(($page - 1) * $itemsPerPage)
-                 ->setMaxResults($itemsPerPage);
-
-        return $this;
-    }
-
-    public function fetchArray(): array
-    {
-        return $this->qb->getQuery()->getResult();
-    }
-
-    public function createQueryBuilder(): QueryBuilder
-    {
-        return $this->qb;
+        return self::ALIAS;
     }
 }

--- a/src/Infrastructure/Repository/RobotDanceOffRepository.php
+++ b/src/Infrastructure/Repository/RobotDanceOffRepository.php
@@ -19,7 +19,9 @@ final class RobotDanceOffRepository implements RobotDanceOffRepositoryInterface
      */
     public function findAll(ApiFiltersDTO $apiFiltersDTO): array
     {
-        return $this->robotDanceOffQueryBuilder
+        $queryBuilder = $this->robotDanceOffQueryBuilder->create();
+
+        return $queryBuilder
             ->whereClauses(
                 $apiFiltersDTO->getFilters(),
                 $apiFiltersDTO->getOperations()

--- a/src/Infrastructure/Repository/RobotQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotQueryBuilder.php
@@ -2,88 +2,49 @@
 
 namespace App\Infrastructure\Repository;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\QueryBuilder;
 use App\Domain\Entity\Robot;
-use App\Infrastructure\DoctrineComparisonEnum;
+use Doctrine\ORM\QueryBuilder;
 
-final class RobotQueryBuilder
+final class RobotQueryBuilder extends AbstractDoctrineQueryBuilder
 {
     private const ENTITY = Robot::class;
     private const ALIAS = 'r';
 
-    private QueryBuilder $qb;
-
-    public function __construct(private EntityManagerInterface $entityManager)
+    public function whereId(int $id): self
     {
-        $this->qb = $entityManager->createQueryBuilder()
+        $qb = $this->getQueryBuilder();
+
+        $qb->andWhere(sprintf('%s.id = :id', self::ALIAS))
+           ->setParameter('id', $id);
+
+        return $this;
+    }
+
+    public function fetchArray(): array
+    {
+        return $this->fetchArrayResult();
+    }
+
+    public function fetchOne(): ?Robot
+    {
+        $result = $this->fetchOneResult();
+
+        if ($result !== null && !$result instanceof Robot) {
+            throw new \LogicException(sprintf('Expected instance of %s, got %s', Robot::class, get_debug_type($result)));
+        }
+
+        return $result;
+    }
+
+    protected function buildBaseQueryBuilder(): QueryBuilder
+    {
+        return $this->entityManager->createQueryBuilder()
             ->select(self::ALIAS)
             ->from(self::ENTITY, self::ALIAS);
     }
 
-    /**
-     * Add a WHERE clause to filter by ID.
-     */
-    public function whereId(int $id): self
+    protected function alias(): string
     {
-        $this->qb->andWhere(self::ALIAS . '.id = :id')
-                 ->setParameter('id', $id);
-
-        return $this;
-    }
-
-    /**
-     * Add multiple WHERE clauses based on filters and operations.
-     */
-    public function whereClauses(array $filters, array $operations): self
-    {
-        foreach ($filters as $filter => $value) {
-            $operation = $operations[$filter] ?? DoctrineComparisonEnum::eq->value;
-
-            if (!DoctrineComparisonEnum::tryFrom($operation)) {
-                throw new \InvalidArgumentException("Invalid operation: $operation");
-            }
-
-            $this->qb->andWhere(self::ALIAS . ".$filter $operation :$filter")
-                     ->setParameter($filter, $value);
-        }
-        return $this;
-    }
-
-    /**
-     * Add sorting to the query.
-     */
-    public function addSorts(array $sorts): self
-    {
-        foreach ($sorts as $field => $order) {
-            $this->qb->addOrderBy(self::ALIAS . ".$field", $order);
-        }
-        return $this;
-    }
-
-    /**
-     * Add pagination to the query.
-     */
-    public function paginate(int $page, int $itemsPerPage): self
-    {
-        $this->qb->setFirstResult(($page - 1) * $itemsPerPage)
-                 ->setMaxResults($itemsPerPage);
-        return $this;
-    }
-
-    /**
-     * Execute the query and return the result as an array.
-     */
-    public function fetchArray(): array
-    {
-        return $this->qb->getQuery()->getArrayResult();
-    }
-
-    /**
-     * Execute the query and return a single result.
-     */
-    public function fetchOne(): ?Robot
-    {
-        return $this->qb->getQuery()->getOneOrNullResult();
+        return self::ALIAS;
     }
 }

--- a/src/Infrastructure/Repository/RobotRepository.php
+++ b/src/Infrastructure/Repository/RobotRepository.php
@@ -18,7 +18,9 @@ final class RobotRepository implements RobotRepositoryInterface
      */
     public function findAll(ApiFiltersDTO $apiFiltersDTO): array
     {
-        return $this->robotQueryBuilder
+        $queryBuilder = $this->robotQueryBuilder->create();
+
+        return $queryBuilder
             ->whereClauses(
                 $apiFiltersDTO->getFilters(),
                 $apiFiltersDTO->getOperations()
@@ -45,7 +47,9 @@ final class RobotRepository implements RobotRepositoryInterface
      */
     public function findOneBy(int $id): ?Robot
     {
-        return $this->robotQueryBuilder
+        $queryBuilder = $this->robotQueryBuilder->create();
+
+        return $queryBuilder
             ->whereId($id)
             ->fetchOne();
     }

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TestBootstrap.php';
+
+use App\Application\DTO\ApiFiltersDTO;
+use App\Domain\Entity\Robot;
+use App\Domain\Entity\RobotDanceOff;
+use App\Infrastructure\Repository\RobotDanceOffQueryBuilder;
+use App\Infrastructure\Repository\RobotDanceOffRepository;
+use App\Infrastructure\Repository\RobotQueryBuilder;
+use App\Infrastructure\Repository\RobotRepository;
+use Tests\Stub\FakeDoctrineRepository;
+use Tests\Stub\FakeEntityManager;
+
+function assertTrue(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+$datasets = [
+    Robot::class => [
+        ['id' => 1, 'name' => 'Alpha', 'experience' => 10, 'outOfOrder' => false],
+        ['id' => 2, 'name' => 'Beta', 'experience' => 4, 'outOfOrder' => true],
+        ['id' => 3, 'name' => 'Gamma', 'experience' => 7, 'outOfOrder' => false],
+    ],
+    RobotDanceOff::class => [
+        ['id' => 1, 'title' => 'Qualifier', 'winningTeam' => 'Team One'],
+        ['id' => 2, 'title' => 'Final', 'winningTeam' => 'Team Two'],
+    ],
+];
+
+$entityManager = new FakeEntityManager($datasets);
+
+$robotRepository = new RobotRepository(
+    new RobotQueryBuilder($entityManager),
+    new FakeDoctrineRepository()
+);
+
+$firstRobots = $robotRepository->findAll(new ApiFiltersDTO(
+    ['outOfOrder' => false],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($firstRobots) === 2, 'First robot query should return two robots.');
+
+$secondRobots = $robotRepository->findAll(new ApiFiltersDTO(
+    ['outOfOrder' => true],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($secondRobots) === 1, 'Second robot query should return one robot.');
+assertTrue($secondRobots[0]['name'] === 'Beta', 'Filtered robot should be Beta.');
+
+$likeFilteredRobots = $robotRepository->findAll(new ApiFiltersDTO(
+    ['name' => 'amm'],
+    ['name' => 'lk'],
+    [],
+    1,
+    10
+));
+assertTrue(count($likeFilteredRobots) === 1 && $likeFilteredRobots[0]['name'] === 'Gamma', 'LIKE operation should match Gamma robot.');
+
+$experiencedRobots = $robotRepository->findAll(new ApiFiltersDTO(
+    ['experience' => 5],
+    ['experience' => 'gt'],
+    [],
+    1,
+    10
+));
+assertTrue(count($experiencedRobots) === 2, 'Greater-than filter should return two robots.');
+
+$builder = (new RobotQueryBuilder($entityManager))->create();
+$combinedFilters = $builder
+    ->whereClauses(['outOfOrder' => false], [])
+    ->whereClauses(['experience' => 7], [])
+    ->fetchArray();
+assertTrue(count($combinedFilters) === 1 && $combinedFilters[0]['name'] === 'Gamma', 'Chained whereClauses should combine filters.');
+
+$sharedBuilder = new RobotQueryBuilder($entityManager);
+$sharedBuilder->whereClauses(['outOfOrder' => false], [])->fetchArray();
+$resetResult = $sharedBuilder->whereClauses(['outOfOrder' => true], [])->fetchArray();
+assertTrue(count($resetResult) === 1 && $resetResult[0]['name'] === 'Beta', 'Builder should reset state between invocations.');
+
+$robot = (new RobotQueryBuilder($entityManager))
+    ->create()
+    ->whereClauses(['outOfOrder' => false], [])
+    ->whereId(3)
+    ->fetchOne();
+assertTrue($robot !== null && $robot->getName() === 'Gamma', 'whereId should work alongside existing filters.');
+assertTrue($robot->getExperience() === 7, 'findOneBy should hydrate experience property.');
+
+$robotDanceOffRepository = new RobotDanceOffRepository(
+    $entityManager,
+    new RobotDanceOffQueryBuilder($entityManager)
+);
+
+$firstDance = $robotDanceOffRepository->findAll(new ApiFiltersDTO(
+    ['id' => 1],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($firstDance) === 1 && $firstDance[0]['id'] === 1, 'First dance-off query should return ID 1.');
+
+$secondDance = $robotDanceOffRepository->findAll(new ApiFiltersDTO(
+    ['id' => 2],
+    [],
+    [],
+    1,
+    10
+));
+assertTrue(count($secondDance) === 1 && $secondDance[0]['id'] === 2, 'Second dance-off query should return ID 2.');
+
+echo "Repository tests completed successfully.\n";

--- a/tests/Stubs/DoctrineCollectionsStubs.php
+++ b/tests/Stubs/DoctrineCollectionsStubs.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Collections;
+
+interface Collection
+{
+    public function contains(mixed $element): bool;
+
+    public function add(mixed $element): void;
+
+    public function removeElement(mixed $element): void;
+}
+
+final class ArrayCollection implements Collection
+{
+    /** @var array<int, mixed> */
+    private array $elements;
+
+    public function __construct(array $elements = [])
+    {
+        $this->elements = array_values($elements);
+    }
+
+    public function contains(mixed $element): bool
+    {
+        return in_array($element, $this->elements, true);
+    }
+
+    public function add(mixed $element): void
+    {
+        if (!$this->contains($element)) {
+            $this->elements[] = $element;
+        }
+    }
+
+    public function removeElement(mixed $element): void
+    {
+        $this->elements = array_values(
+            array_filter(
+                $this->elements,
+                static fn (mixed $existing): bool => $existing !== $element
+            )
+        );
+    }
+}

--- a/tests/Stubs/DoctrineComparisonStubs.php
+++ b/tests/Stubs/DoctrineComparisonStubs.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Collections\Expr;
+
+final class Comparison
+{
+    public const EQ = '=';
+    public const NEQ = '!=';
+    public const GT = '>';
+    public const GTE = '>=';
+    public const LT = '<';
+    public const LTE = '<=';
+    public const CONTAINS = 'LIKE';
+    public const IN = 'IN';
+}

--- a/tests/Stubs/DoctrineMappingStubs.php
+++ b/tests/Stubs/DoctrineMappingStubs.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Entity
+{
+    public function __construct(public ?string $repositoryClass = null)
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Table
+{
+    public function __construct(public ?string $name = null)
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Id
+{
+    public function __construct()
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class GeneratedValue
+{
+    public function __construct()
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Column
+{
+    public function __construct(
+        public ?string $type = null,
+        public ?int $length = null,
+        public bool $nullable = false
+    ) {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ManyToMany
+{
+    public function __construct(
+        public ?string $mappedBy = null,
+        public ?string $targetEntity = null
+    ) {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class JoinTable
+{
+    public function __construct(public ?string $name = null)
+    {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ManyToOne
+{
+    public function __construct(
+        public ?string $targetEntity = null,
+        public array $cascade = []
+    ) {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class JoinColumn
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $referencedColumnName = null,
+        public bool $nullable = true
+    ) {
+    }
+}

--- a/tests/Stubs/DoctrineOrmStubs.php
+++ b/tests/Stubs/DoctrineOrmStubs.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM;
+
+final class Query
+{
+    /**
+     * @param array<int, array<string, mixed>|object> $results
+     */
+    public function __construct(private array $results, private ?string $entityClass = null)
+    {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getArrayResult(): array
+    {
+        return array_map([$this, 'normalize'], $this->results);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getResult(): array
+    {
+        return $this->getArrayResult();
+    }
+
+    public function getOneOrNullResult(): ?object
+    {
+        if ($this->results === []) {
+            return null;
+        }
+
+        $first = $this->results[0];
+
+        if (is_object($first)) {
+            return $first;
+        }
+
+        if ($this->entityClass === null || !class_exists($this->entityClass)) {
+            return (object) $first;
+        }
+
+        return $this->hydrateEntity($first);
+    }
+
+    /**
+     * @param array<string, mixed>|object $row
+     * @return array<string, mixed>
+     */
+    private function normalize(array|object $row): array
+    {
+        if (is_array($row)) {
+            return $row;
+        }
+
+        $data = [];
+        $reflection = new \ReflectionObject($row);
+        foreach ($reflection->getProperties() as $property) {
+            $property->setAccessible(true);
+            $data[$property->getName()] = $property->getValue($row);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrateEntity(array $row): object
+    {
+        $entityClass = $this->entityClass;
+        $entity = new $entityClass();
+
+        foreach ($row as $field => $value) {
+            $method = 'set' . ucfirst($field);
+            if (method_exists($entity, $method)) {
+                $entity->$method($value);
+                continue;
+            }
+
+            $this->setProperty($entity, $field, $value);
+        }
+
+        return $entity;
+    }
+
+    private function setProperty(object $entity, string $field, mixed $value): void
+    {
+        $reflection = new \ReflectionObject($entity);
+        if (!$reflection->hasProperty($field)) {
+            return;
+        }
+
+        $property = $reflection->getProperty($field);
+        $property->setAccessible(true);
+        $property->setValue($entity, $value);
+    }
+}
+
+interface EntityManagerInterface
+{
+    public function createQueryBuilder(): QueryBuilder;
+
+    public function persist(object $entity): void;
+
+    public function flush(): void;
+
+    public function remove(object $entity): void;
+
+    public function getRepository(string $className): object;
+}
+
+final class QueryBuilder
+{
+    private ?string $entityClass = null;
+
+    private ?string $alias = null;
+
+    /** @var array<string, mixed> */
+    private array $parameters = [];
+
+    /** @var array<int, array{field: string, operator: string, parameter: string}> */
+    private array $conditions = [];
+
+    /** @var array<int, array{field: string, direction: string}> */
+    private array $orderBy = [];
+
+    private ?int $firstResult = null;
+
+    private ?int $maxResults = null;
+
+    /** @var array<int, array<string, mixed>> */
+    private array $data = [];
+
+    /** @param array<class-string, array<int, array<string, mixed>>> $datasets */
+    public function __construct(private array $datasets = [])
+    {
+    }
+
+    public function select(string ...$select): self
+    {
+        return $this;
+    }
+
+    public function from(string $entityClass, string $alias): self
+    {
+        $this->entityClass = $entityClass;
+        $this->alias = $alias;
+        $this->data = $this->datasets[$entityClass] ?? [];
+
+        return $this;
+    }
+
+    public function leftJoin(string $from, string $alias, ?string $conditionType = null, ?string $condition = null): self
+    {
+        return $this;
+    }
+
+    public function andWhere(string $condition): self
+    {
+        $pattern = '/^([a-zA-Z0-9_\.]+)\s*(=|!=|>=|<=|>|<|LIKE|IN)\s*:(\w+)$/';
+        if (!preg_match($pattern, $condition, $matches)) {
+            throw new \InvalidArgumentException(sprintf('Unsupported condition "%s".', $condition));
+        }
+
+        $this->conditions[] = [
+            'field' => $matches[1],
+            'operator' => strtoupper($matches[2]),
+            'parameter' => $matches[3],
+        ];
+
+        return $this;
+    }
+
+    public function setParameter(string $name, mixed $value): self
+    {
+        $this->parameters[$name] = $value;
+
+        return $this;
+    }
+
+    public function addOrderBy(string $field, string $direction): self
+    {
+        $this->orderBy[] = [
+            'field' => $field,
+            'direction' => strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC',
+        ];
+
+        return $this;
+    }
+
+    public function setFirstResult(int $firstResult): self
+    {
+        $this->firstResult = max(0, $firstResult);
+
+        return $this;
+    }
+
+    public function setMaxResults(int $maxResults): self
+    {
+        $this->maxResults = $maxResults >= 0 ? $maxResults : null;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getRootAliases(): array
+    {
+        return $this->alias !== null ? [$this->alias] : [];
+    }
+
+    public function getQuery(): Query
+    {
+        $results = $this->applyConditions($this->data);
+        $results = $this->applySorting($results);
+        $results = $this->applyPagination($results);
+
+        return new Query($results, $this->entityClass);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $dataset
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyConditions(array $dataset): array
+    {
+        if ($this->conditions === []) {
+            return $dataset;
+        }
+
+        return array_values(array_filter(
+            $dataset,
+            function (array $row): bool {
+                foreach ($this->conditions as $condition) {
+                    $field = $this->extractField($condition['field']);
+                    $value = $row[$field] ?? null;
+                    $parameter = $this->parameters[$condition['parameter']] ?? null;
+
+                    if (!$this->compare($value, $parameter, $condition['operator'])) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        ));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $dataset
+     * @return array<int, array<string, mixed>>
+     */
+    private function applySorting(array $dataset): array
+    {
+        if ($this->orderBy === []) {
+            return $dataset;
+        }
+
+        usort(
+            $dataset,
+            function (array $left, array $right): int {
+                foreach ($this->orderBy as $order) {
+                    $field = $this->extractField($order['field']);
+                    $leftValue = $left[$field] ?? null;
+                    $rightValue = $right[$field] ?? null;
+
+                    if ($leftValue === $rightValue) {
+                        continue;
+                    }
+
+                    $comparison = $leftValue <=> $rightValue;
+                    if ($order['direction'] === 'DESC') {
+                        $comparison *= -1;
+                    }
+
+                    if ($comparison !== 0) {
+                        return $comparison;
+                    }
+                }
+
+                return 0;
+            }
+        );
+
+        return $dataset;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $dataset
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyPagination(array $dataset): array
+    {
+        if ($this->firstResult === null && $this->maxResults === null) {
+            return $dataset;
+        }
+
+        $offset = $this->firstResult ?? 0;
+        $length = $this->maxResults ?? null;
+
+        return array_slice($dataset, $offset, $length);
+    }
+
+    private function extractField(string $expression): string
+    {
+        $parts = explode('.', $expression);
+
+        return (string) end($parts);
+    }
+
+    private function compare(mixed $fieldValue, mixed $parameterValue, string $operator): bool
+    {
+        $operator = strtoupper($operator);
+
+        return match ($operator) {
+            '=', 'EQ' => $fieldValue == $parameterValue,
+            '!=', '<>' => $fieldValue != $parameterValue,
+            '>', 'GT' => $fieldValue > $parameterValue,
+            '>=', 'GTE' => $fieldValue >= $parameterValue,
+            '<', 'LT' => $fieldValue < $parameterValue,
+            '<=', 'LTE' => $fieldValue <= $parameterValue,
+            'LIKE' => $this->compareLike($fieldValue, $parameterValue),
+            'IN' => in_array($fieldValue, (array) $parameterValue, true),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported operator "%s".', $operator)),
+        };
+    }
+
+    private function compareLike(mixed $fieldValue, mixed $parameterValue): bool
+    {
+        $needle = is_string($parameterValue) ? trim($parameterValue, '%') : '';
+
+        return is_string($fieldValue) && str_contains(strtolower($fieldValue), strtolower($needle));
+    }
+}

--- a/tests/Stubs/FakeDoctrineRepository.php
+++ b/tests/Stubs/FakeDoctrineRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub;
+
+use App\Infrastructure\Repository\DoctrineRepositoryInterface;
+
+final class FakeDoctrineRepository implements DoctrineRepositoryInterface
+{
+    public function createQueryBuilder(string $entityClass, string $entityAlias): self
+    {
+        return $this;
+    }
+
+    public function whereEqual(string $field, mixed $value): self
+    {
+        return $this;
+    }
+
+    public function whereLike(string $field, mixed $value): self
+    {
+        return $this;
+    }
+
+    public function buildSorts(array $sorts): self
+    {
+        return $this;
+    }
+
+    public function buildPagination(int $page, int $itemsPerPage): self
+    {
+        return $this;
+    }
+
+    public function fetchArray(): array
+    {
+        return [];
+    }
+
+    public function findOne(): ?object
+    {
+        return null;
+    }
+
+    public function persist(object $entity): void
+    {
+    }
+
+    public function save(): void
+    {
+    }
+
+    public function remove(object $entity): void
+    {
+    }
+}

--- a/tests/Stubs/FakeEntityManager.php
+++ b/tests/Stubs/FakeEntityManager.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final class FakeEntityManager implements EntityManagerInterface
+{
+    /**
+     * @param array<class-string, array<int, array<string, mixed>>> $datasets
+     */
+    public function __construct(private array $datasets)
+    {
+    }
+
+    public function createQueryBuilder(): QueryBuilder
+    {
+        return new QueryBuilder($this->datasets);
+    }
+
+    public function persist(object $entity): void
+    {
+    }
+
+    public function flush(): void
+    {
+    }
+
+    public function remove(object $entity): void
+    {
+    }
+
+    public function getRepository(string $className): object
+    {
+        return new FakeObjectRepository($this->datasets[$className] ?? []);
+    }
+}

--- a/tests/Stubs/FakeObjectRepository.php
+++ b/tests/Stubs/FakeObjectRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub;
+
+final class FakeObjectRepository
+{
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     */
+    public function __construct(private array $rows)
+    {
+    }
+
+    public function find(int $id): ?object
+    {
+        foreach ($this->rows as $row) {
+            if (($row['id'] ?? null) === $id) {
+                return (object) $row;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/TestBootstrap.php
+++ b/tests/TestBootstrap.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Stubs/DoctrineMappingStubs.php';
+require_once __DIR__ . '/Stubs/DoctrineCollectionsStubs.php';
+require_once __DIR__ . '/Stubs/DoctrineComparisonStubs.php';
+require_once __DIR__ . '/Stubs/DoctrineOrmStubs.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../src/';
+
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relativeClass = substr($class, strlen($prefix));
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
+// Handle classes that live outside of the PSR-4 directory expectations in this
+// lightweight test environment.
+require_once __DIR__ . '/../src/Infrastructure/Repository/DoctrineComparisonEnum.php';
+
+require_once __DIR__ . '/Stubs/FakeEntityManager.php';
+require_once __DIR__ . '/Stubs/FakeObjectRepository.php';
+require_once __DIR__ . '/Stubs/FakeDoctrineRepository.php';


### PR DESCRIPTION
## Summary
- introduce an AbstractDoctrineQueryBuilder that encapsulates query builder creation, default criteria hooks, and filter/sort/pagination helpers so each invocation starts from a clean slate
- update RobotQueryBuilder and RobotDanceOffQueryBuilder to extend the shared base, preserving chained filters and mapping comparison operations (including LIKE) correctly on every request
- expand the lightweight repository regression script to cover chained filters, builder reuse, and LIKE/greater-than scenarios to guard against filter leakage regressions

## Testing
- php tests/Repository/RepositoryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d0bb9667d48320815e9f61fe713031