### PR TITLE
Fix request filter parsing

### DIFF
--- a/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
+++ b/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
@@ -2,7 +2,7 @@
 
 namespace App\Infrastructure\Repository;
 
-use App\Infrastructure\DoctrineComparisonEnum;
+use App\Infrastructure\Repository\DoctrineComparisonEnum;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Infrastructure/Repository/DoctrineComparisonFilterTrait.php
+++ b/src/Infrastructure/Repository/DoctrineComparisonFilterTrait.php
@@ -2,7 +2,7 @@
 
 namespace App\Infrastructure\Repository;
 
-use App\Infrastructure\DoctrineComparisonEnum;
+use App\Infrastructure\Repository\DoctrineComparisonEnum;
 use Doctrine\ORM\QueryBuilder;
 use InvalidArgumentException;
 use ValueError;

--- a/tests/Application/Request/RequestDataMapperTest.php
+++ b/tests/Application/Request/RequestDataMapperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Request;
+
+use App\Application\Request\RequestDataMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class RequestDataMapperTest extends TestCase
+{
+    public function testItParsesFiltersFromQueryParameters(): void
+    {
+        $requestStack = new RequestStack();
+        $request = Request::create(
+            '/robots',
+            'GET',
+            [
+                'filter' => ['name' => ['lk' => 'Bender']],
+                'id' => ['eq' => '2'],
+                'orderBy' => ['name' => 'ASC'],
+                'page' => '3',
+                'itemsPerPage' => '25',
+            ]
+        );
+
+        $requestStack->push($request);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertEquals(
+            ['name' => 'Bender', 'id' => '2'],
+            $requestDataMapper->getFilters()
+        );
+
+        self::assertEquals(
+            ['name' => 'lk', 'id' => 'eq'],
+            $requestDataMapper->getOperations()
+        );
+    }
+
+    public function testItDefaultsOperationToEqForScalarFilters(): void
+    {
+        $requestStack = new RequestStack();
+        $request = Request::create(
+            '/robots',
+            'GET',
+            [
+                'experience' => '42',
+            ]
+        );
+
+        $requestStack->push($request);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertEquals(['experience' => '42'], $requestDataMapper->getFilters());
+        self::assertEquals(['experience' => 'eq'], $requestDataMapper->getOperations());
+    }
+
+    public function testItKeepsZeroValues(): void
+    {
+        $requestStack = new RequestStack();
+        $request = Request::create(
+            '/robots',
+            'GET',
+            [
+                'id' => ['eq' => '0'],
+            ]
+        );
+
+        $requestStack->push($request);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertEquals(['id' => '0'], $requestDataMapper->getFilters());
+        self::assertEquals(['id' => 'eq'], $requestDataMapper->getOperations());
+    }
+}

--- a/tests/Application/Request/RequestDataMapperTest.php
+++ b/tests/Application/Request/RequestDataMapperTest.php
@@ -78,4 +78,32 @@ final class RequestDataMapperTest extends TestCase
         self::assertEquals(['id' => '0'], $requestDataMapper->getFilters());
         self::assertEquals(['id' => 'eq'], $requestDataMapper->getOperations());
     }
+
+    public function testItRefreshesParametersForSubsequentRequests(): void
+    {
+        $requestStack = new RequestStack();
+
+        $firstRequest = Request::create('/robots', 'GET');
+        $requestStack->push($firstRequest);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertSame([], $requestDataMapper->getFilters());
+        self::assertSame([], $requestDataMapper->getOperations());
+
+        $requestStack->pop();
+
+        $secondRequest = Request::create(
+            '/robots',
+            'GET',
+            [
+                'id' => ['eq' => '2'],
+            ]
+        );
+
+        $requestStack->push($secondRequest);
+
+        self::assertEquals(['id' => '2'], $requestDataMapper->getFilters());
+        self::assertEquals(['id' => 'eq'], $requestDataMapper->getOperations());
+    }
 }


### PR DESCRIPTION
## Summary
- update the RequestDataMapper to collect filters from both the `filter[...]` bag and top-level query parameters so requests like `id[eq]=2` are parsed correctly
- default scalar query values to the `eq` operator and keep zero-valued filters while skipping pagination/sort keys
- add unit tests covering the updated filter extraction logic
