### PR TITLE
Fix RobotDanceOff repository to return entities

### DIFF
--- a/src/Application/Request/RequestDataMapper.php
+++ b/src/Application/Request/RequestDataMapper.php
@@ -7,33 +7,37 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class RequestDataMapper
 {
-    private ParameterBag $parameterBag;
     private const FILTER_KEY = 'filter';
     private const SORT_KEY = 'orderBy';
+    private const DEFAULT_OPERATION = 'eq';
+    private const IGNORED_QUERY_PARAMETERS = [
+        self::FILTER_KEY,
+        self::SORT_KEY,
+        'page',
+        'itemsPerPage',
+    ];
 
     public function __construct(private RequestStack $requestStack)
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if ($request) {
-            $this->parameterBag = new ParameterBag(parameters: $request->query->all());
-        } else {
-            throw new \RuntimeException('Request could not be fetched from the RequestStack.');
-        }
     }
 
     public function getFilters(): array
     {
-        $rawFilters = $this->parameterBag->get(self::FILTER_KEY, []);
         $parsedFilters = [];
 
-        foreach ($rawFilters as $field => $condition) {
+        foreach ($this->collectRawFilters() as $field => $condition) {
             if (is_array($condition)) {
-                $operation = key($condition);
-                $value = $condition[$operation];
+                foreach ($condition as $operation => $value) {
+                    if ($operation === null || $operation === '' || $value === null || $value === '') {
+                        continue;
+                    }
 
-                if (!empty($value) && !empty($operation)) {
                     $parsedFilters[$field] = $value;
+
+                    break;
                 }
+            } elseif ($condition !== null && $condition !== '') {
+                $parsedFilters[$field] = $condition;
             }
         }
 
@@ -42,15 +46,21 @@ final class RequestDataMapper
 
     public function getOperations(): array
     {
-        $rawFilters = $this->parameterBag->get(self::FILTER_KEY, []);
         $parsedOperations = [];
 
-        foreach ($rawFilters as $field => $condition) {
+        foreach ($this->collectRawFilters() as $field => $condition) {
             if (is_array($condition)) {
-                $operation = key($condition);
-                if (!empty($operation)) {
+                foreach ($condition as $operation => $value) {
+                    if ($operation === null || $operation === '' || $value === null || $value === '') {
+                        continue;
+                    }
+
                     $parsedOperations[$field] = $operation;
+
+                    break;
                 }
+            } elseif ($condition !== null && $condition !== '') {
+                $parsedOperations[$field] = self::DEFAULT_OPERATION;
             }
         }
 
@@ -59,14 +69,50 @@ final class RequestDataMapper
 
     public function getSorts(): array
     {
-        return $this->parameterBag->get(self::SORT_KEY, []);
+        return $this->getParameterBag()->get(self::SORT_KEY, []);
     }
 
     public function getPagination(): array
     {
+        $parameterBag = $this->getParameterBag();
+
         return [
-            'page' => (int) $this->parameterBag->get('page', 1),
-            'itemsPerPage' => (int) $this->parameterBag->get('itemsPerPage', 10),
+            'page' => (int) $parameterBag->get('page', 1),
+            'itemsPerPage' => (int) $parameterBag->get('itemsPerPage', 10),
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collectRawFilters(): array
+    {
+        $parameterBag = $this->getParameterBag();
+        $rawFilters = $parameterBag->get(self::FILTER_KEY, []);
+
+        if (!is_array($rawFilters)) {
+            $rawFilters = [];
+        }
+
+        foreach ($parameterBag->all() as $key => $value) {
+            if (in_array($key, self::IGNORED_QUERY_PARAMETERS, true) || $value === null) {
+                continue;
+            }
+
+            $rawFilters[$key] = $value;
+        }
+
+        return $rawFilters;
+    }
+
+    private function getParameterBag(): ParameterBag
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request === null) {
+            throw new \RuntimeException('Request could not be fetched from the RequestStack.');
+        }
+
+        return new ParameterBag(parameters: $request->query->all());
     }
 }

--- a/src/Domain/Repository/RobotDanceOffRepositoryInterface.php
+++ b/src/Domain/Repository/RobotDanceOffRepositoryInterface.php
@@ -7,6 +7,9 @@ use App\Application\DTO\ApiFiltersDTO;
 
 interface RobotDanceOffRepositoryInterface
 {
+    /**
+     * @return array<int, RobotDanceOff>
+     */
     public function findAll(ApiFiltersDTO $apiFiltersDTO): array;
 
     public function findOneBy(int $id): ?RobotDanceOff;

--- a/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
+++ b/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
@@ -67,6 +67,9 @@ abstract class AbstractDoctrineQueryBuilder
         return $this;
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
     protected function fetchArrayResult(): array
     {
         $qb = $this->getQueryBuilder();

--- a/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
+++ b/src/Infrastructure/Repository/AbstractDoctrineQueryBuilder.php
@@ -2,7 +2,7 @@
 
 namespace App\Infrastructure\Repository;
 
-use App\Infrastructure\DoctrineComparisonEnum;
+use App\Infrastructure\Repository\DoctrineComparisonEnum;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
@@ -71,6 +71,18 @@ abstract class AbstractDoctrineQueryBuilder
     {
         $qb = $this->getQueryBuilder();
         $results = $qb->getQuery()->getArrayResult();
+        $this->clearQueryBuilder();
+
+        return $results;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function fetchResult(): array
+    {
+        $qb = $this->getQueryBuilder();
+        $results = $qb->getQuery()->getResult();
         $this->clearQueryBuilder();
 
         return $results;

--- a/src/Infrastructure/Repository/DoctrineComparisonFilterTrait.php
+++ b/src/Infrastructure/Repository/DoctrineComparisonFilterTrait.php
@@ -2,7 +2,7 @@
 
 namespace App\Infrastructure\Repository;
 
-use App\Infrastructure\DoctrineComparisonEnum;
+use App\Infrastructure\Repository\DoctrineComparisonEnum;
 use Doctrine\ORM\QueryBuilder;
 use InvalidArgumentException;
 use ValueError;

--- a/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
+++ b/src/Infrastructure/Repository/RobotDanceOffQueryBuilder.php
@@ -4,6 +4,7 @@ namespace App\Infrastructure\Repository;
 
 use App\Domain\Entity\RobotDanceOff;
 use Doctrine\ORM\QueryBuilder;
+use UnexpectedValueException;
 
 final class RobotDanceOffQueryBuilder extends AbstractDoctrineQueryBuilder
 {
@@ -34,5 +35,39 @@ final class RobotDanceOffQueryBuilder extends AbstractDoctrineQueryBuilder
     public function fetchArray(): array
     {
         return $this->fetchArrayResult();
+    }
+
+    /**
+     * @return array<int, RobotDanceOff>
+     */
+    public function fetch(): array
+    {
+        $results = $this->fetchResult();
+
+        return array_map(function (mixed $row): RobotDanceOff {
+            if ($row instanceof RobotDanceOff) {
+                return $row;
+            }
+
+            if (is_array($row)) {
+                $byAlias = $row[self::ALIAS] ?? null;
+                if ($byAlias instanceof RobotDanceOff) {
+                    return $byAlias;
+                }
+
+                $first = $row[0] ?? null;
+                if ($first instanceof RobotDanceOff) {
+                    return $first;
+                }
+
+                foreach ($row as $value) {
+                    if ($value instanceof RobotDanceOff) {
+                        return $value;
+                    }
+                }
+            }
+
+            throw new UnexpectedValueException('Expected RobotDanceOff instance from query result.');
+        }, $results);
     }
 }

--- a/src/Infrastructure/Repository/RobotDanceOffRepository.php
+++ b/src/Infrastructure/Repository/RobotDanceOffRepository.php
@@ -16,6 +16,8 @@ final class RobotDanceOffRepository implements RobotDanceOffRepositoryInterface
 
     /**
      * Fetch all dance-offs with filters and sorting.
+     *
+     * @return array<int, RobotDanceOff>
      */
     public function findAll(ApiFiltersDTO $apiFiltersDTO): array
     {
@@ -31,7 +33,7 @@ final class RobotDanceOffRepository implements RobotDanceOffRepositoryInterface
                 $apiFiltersDTO->getPage(),
                 $apiFiltersDTO->getItemsPerPage()
             )
-            ->fetchArray();
+            ->fetch();
     }
 
     /**

--- a/tests/Application/Request/RequestDataMapperTest.php
+++ b/tests/Application/Request/RequestDataMapperTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Request;
+
+use App\Application\Request\RequestDataMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class RequestDataMapperTest extends TestCase
+{
+    public function testItParsesFiltersFromQueryParameters(): void
+    {
+        $requestStack = new RequestStack();
+        $request = Request::create(
+            '/robots',
+            'GET',
+            [
+                'filter' => ['name' => ['lk' => 'Bender']],
+                'id' => ['eq' => '2'],
+                'orderBy' => ['name' => 'ASC'],
+                'page' => '3',
+                'itemsPerPage' => '25',
+            ]
+        );
+
+        $requestStack->push($request);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertEquals(
+            ['name' => 'Bender', 'id' => '2'],
+            $requestDataMapper->getFilters()
+        );
+
+        self::assertEquals(
+            ['name' => 'lk', 'id' => 'eq'],
+            $requestDataMapper->getOperations()
+        );
+    }
+
+    public function testItDefaultsOperationToEqForScalarFilters(): void
+    {
+        $requestStack = new RequestStack();
+        $request = Request::create(
+            '/robots',
+            'GET',
+            [
+                'experience' => '42',
+            ]
+        );
+
+        $requestStack->push($request);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertEquals(['experience' => '42'], $requestDataMapper->getFilters());
+        self::assertEquals(['experience' => 'eq'], $requestDataMapper->getOperations());
+    }
+
+    public function testItKeepsZeroValues(): void
+    {
+        $requestStack = new RequestStack();
+        $request = Request::create(
+            '/robots',
+            'GET',
+            [
+                'id' => ['eq' => '0'],
+            ]
+        );
+
+        $requestStack->push($request);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertEquals(['id' => '0'], $requestDataMapper->getFilters());
+        self::assertEquals(['id' => 'eq'], $requestDataMapper->getOperations());
+    }
+
+    public function testItRefreshesParametersForSubsequentRequests(): void
+    {
+        $requestStack = new RequestStack();
+
+        $firstRequest = Request::create('/robots', 'GET');
+        $requestStack->push($firstRequest);
+
+        $requestDataMapper = new RequestDataMapper($requestStack);
+
+        self::assertSame([], $requestDataMapper->getFilters());
+        self::assertSame([], $requestDataMapper->getOperations());
+
+        $requestStack->pop();
+
+        $secondRequest = Request::create(
+            '/robots',
+            'GET',
+            [
+                'id' => ['eq' => '2'],
+            ]
+        );
+
+        $requestStack->push($secondRequest);
+
+        self::assertEquals(['id' => '2'], $requestDataMapper->getFilters());
+        self::assertEquals(['id' => 'eq'], $requestDataMapper->getOperations());
+    }
+}

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../TestBootstrap.php';
 use App\Application\DTO\ApiFiltersDTO;
 use App\Domain\Entity\Robot;
 use App\Domain\Entity\RobotDanceOff;
+use App\Domain\Entity\Team;
 use App\Infrastructure\Repository\RobotDanceOffQueryBuilder;
 use App\Infrastructure\Repository\RobotDanceOffRepository;
 use App\Infrastructure\Repository\RobotQueryBuilder;
@@ -21,6 +22,76 @@ function assertTrue(bool $condition, string $message): void
     }
 }
 
+function setProperty(object $entity, string $property, mixed $value): void
+{
+    $reflection = new \ReflectionObject($entity);
+    if (!$reflection->hasProperty($property)) {
+        return;
+    }
+
+    $propertyRef = $reflection->getProperty($property);
+    $propertyRef->setAccessible(true);
+    $propertyRef->setValue($entity, $value);
+}
+
+function createRobotEntity(int $id, string $name, int $experience, bool $outOfOrder, string $powermove): Robot
+{
+    $robot = new Robot();
+    setProperty($robot, 'id', $id);
+    $robot
+        ->setName($name)
+        ->setExperience($experience)
+        ->setOutOfOrder($outOfOrder)
+        ->setPowermove($powermove)
+        ->setAvatar(sprintf('avatar-%d.png', $id));
+
+    return $robot;
+}
+
+function createTeamEntity(int $id, string $name, Robot ...$robots): Team
+{
+    $team = new Team($name);
+    setProperty($team, 'id', $id);
+
+    foreach ($robots as $robot) {
+        $team->addRobot($robot);
+    }
+
+    return $team;
+}
+
+function createDanceOffEntity(
+    int $id,
+    Team $teamOne,
+    Team $teamTwo,
+    ?Team $winningTeam,
+    \DateTime $createdAt
+): RobotDanceOff {
+    $danceOff = new RobotDanceOff();
+    setProperty($danceOff, 'id', $id);
+    setProperty($danceOff, 'createdAt', $createdAt);
+
+    $danceOff->setTeamOne($teamOne);
+    $danceOff->setTeamTwo($teamTwo);
+
+    if ($winningTeam !== null) {
+        $danceOff->setWinningTeam($winningTeam);
+    }
+
+    return $danceOff;
+}
+
+$alphaRobot = createRobotEntity(1, 'Alpha', 10, false, 'Spin Move');
+$betaRobot = createRobotEntity(2, 'Beta', 4, true, 'Power Stomp');
+$gammaRobot = createRobotEntity(3, 'Gamma', 7, false, 'Laser Slide');
+
+$teamOne = createTeamEntity(101, 'Team One', $alphaRobot);
+$teamTwo = createTeamEntity(102, 'Team Two', $betaRobot);
+$teamThree = createTeamEntity(103, 'Team Three', $gammaRobot);
+
+$firstDanceOff = createDanceOffEntity(1, $teamOne, $teamTwo, $teamOne, new \DateTime('2024-01-01 12:00:00'));
+$secondDanceOff = createDanceOffEntity(2, $teamTwo, $teamThree, $teamTwo, new \DateTime('2024-01-02 12:00:00'));
+
 $datasets = [
     Robot::class => [
         ['id' => 1, 'name' => 'Alpha', 'experience' => 10, 'outOfOrder' => false],
@@ -28,8 +99,8 @@ $datasets = [
         ['id' => 3, 'name' => 'Gamma', 'experience' => 7, 'outOfOrder' => false],
     ],
     RobotDanceOff::class => [
-        ['id' => 1, 'title' => 'Qualifier', 'winningTeam' => 'Team One'],
-        ['id' => 2, 'title' => 'Final', 'winningTeam' => 'Team Two'],
+        $firstDanceOff,
+        $secondDanceOff,
     ],
 ];
 
@@ -75,7 +146,10 @@ $firstDance = $robotDanceOffRepository->findAll(new ApiFiltersDTO(
     1,
     10
 ));
-assertTrue(count($firstDance) === 1 && $firstDance[0]['id'] === 1, 'First dance-off query should return ID 1.');
+assertTrue(count($firstDance) === 1, 'First dance-off query should return one result.');
+assertTrue($firstDance[0] instanceof RobotDanceOff, 'Dance-off result should be a RobotDanceOff entity.');
+assertTrue($firstDance[0]->getId() === 1, 'First dance-off query should return ID 1.');
+assertTrue($firstDance[0]->getWinningTeam()?->getName() === 'Team One', 'Winning team should be Team One.');
 
 $secondDance = $robotDanceOffRepository->findAll(new ApiFiltersDTO(
     ['id' => 2],
@@ -84,6 +158,9 @@ $secondDance = $robotDanceOffRepository->findAll(new ApiFiltersDTO(
     1,
     10
 ));
-assertTrue(count($secondDance) === 1 && $secondDance[0]['id'] === 2, 'Second dance-off query should return ID 2.');
+assertTrue(count($secondDance) === 1, 'Second dance-off query should return one result.');
+assertTrue($secondDance[0] instanceof RobotDanceOff, 'Dance-off result should be a RobotDanceOff entity.');
+assertTrue($secondDance[0]->getId() === 2, 'Second dance-off query should return ID 2.');
+assertTrue($secondDance[0]->getWinningTeam()?->getName() === 'Team Two', 'Winning team should be Team Two.');
 
 echo "Repository tests completed successfully.\n";

--- a/tests/Responder/RobotDanceOffResponderTest.php
+++ b/tests/Responder/RobotDanceOffResponderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TestBootstrap.php';
+
+use App\Domain\Entity\Robot;
+use App\Domain\Entity\RobotDanceOff;
+use App\Domain\Entity\Team;
+use App\Infrastructure\Response\RobotDanceOffResponse;
+use App\Responder\RobotDanceOffResponder;
+use Doctrine\Common\Collections\Collection;
+
+function assertTrue(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function setProperty(object $entity, string $property, mixed $value): void
+{
+    $reflection = new \ReflectionObject($entity);
+    if (!$reflection->hasProperty($property)) {
+        return;
+    }
+
+    $propertyRef = $reflection->getProperty($property);
+    $propertyRef->setAccessible(true);
+    $propertyRef->setValue($entity, $value);
+}
+
+function createRobot(int $id, string $name, string $powermove, int $experience, bool $outOfOrder, ?string $avatar): Robot
+{
+    $robot = new Robot();
+    setProperty($robot, 'id', $id);
+    $robot
+        ->setName($name)
+        ->setPowermove($powermove)
+        ->setExperience($experience)
+        ->setOutOfOrder($outOfOrder)
+        ->setAvatar($avatar);
+
+    return $robot;
+}
+
+function createTeam(int $id, string $name, Robot ...$robots): Team
+{
+    $team = new Team($name);
+    setProperty($team, 'id', $id);
+
+    foreach ($robots as $robot) {
+        $team->addRobot($robot);
+    }
+
+    return $team;
+}
+
+$robotOne = createRobot(1, 'Atlas', 'Flare', 12, false, 'atlas.png');
+$robotTwo = createRobot(2, 'Bolt', 'Slide', 8, false, 'bolt.png');
+$robotThree = createRobot(3, 'Circuit', 'Spin', 6, true, 'circuit.png');
+
+$teamAlpha = createTeam(10, 'Alpha Team', $robotOne, $robotTwo);
+$teamBeta = createTeam(20, 'Beta Squad', $robotThree);
+
+$danceOff = new RobotDanceOff();
+setProperty($danceOff, 'id', 42);
+setProperty($danceOff, 'createdAt', new \DateTime('2024-03-01 09:30:00'));
+$danceOff->setTeamOne($teamAlpha);
+$danceOff->setTeamTwo($teamBeta);
+$danceOff->setWinningTeam($teamAlpha);
+
+$responder = new RobotDanceOffResponder();
+$responses = $responder->respond([$danceOff]);
+
+assertTrue($responses instanceof Collection, 'Responder should return a Doctrine Collection.');
+assertTrue($responses->count() === 1, 'Responder should produce one response item.');
+
+$firstResponse = $responses->first();
+assertTrue($firstResponse instanceof RobotDanceOffResponse, 'Responder should map entities to RobotDanceOffResponse objects.');
+assertTrue($firstResponse->getId() === 42, 'Response should expose the dance-off ID.');
+
+$teamOneDetails = $firstResponse->getTeamOne();
+assertTrue($teamOneDetails['id'] === 10, 'Team One ID should match the entity.');
+assertTrue($teamOneDetails['name'] === 'Alpha Team', 'Team One name should match the entity.');
+assertTrue(count($teamOneDetails['robots']) === 2, 'Team One should list both robots.');
+$firstRobot = $teamOneDetails['robots'][0];
+assertTrue($firstRobot['id'] === 1, 'Mapped robot should include its ID.');
+assertTrue($firstRobot['powermove'] === 'Flare', 'Mapped robot should include powermove details.');
+
+$winningTeamDetails = $firstResponse->getWinningTeam();
+assertTrue($winningTeamDetails !== null, 'Winning team should be present.');
+assertTrue($winningTeamDetails['name'] === 'Alpha Team', 'Winning team name should match the entity.');
+assertTrue(count($winningTeamDetails['robots']) === 2, 'Winning team robots should be mapped.');
+
+$teamTwoDetails = $firstResponse->getTeamTwo();
+assertTrue($teamTwoDetails['id'] === 20, 'Team Two ID should match the entity.');
+assertTrue(count($teamTwoDetails['robots']) === 1, 'Team Two should list its single robot.');
+assertTrue($teamTwoDetails['robots'][0]['outOfOrder'] === true, 'Robot attributes should include the outOfOrder flag.');
+
+echo "RobotDanceOffResponder tests completed successfully.\n";

--- a/tests/Stubs/DoctrineCollectionsStubs.php
+++ b/tests/Stubs/DoctrineCollectionsStubs.php
@@ -11,6 +11,14 @@ interface Collection
     public function add(mixed $element): void;
 
     public function removeElement(mixed $element): void;
+
+    public function map(callable $callback): self;
+
+    public function toArray(): array;
+
+    public function count(): int;
+
+    public function first(): mixed;
 }
 
 final class ArrayCollection implements Collection
@@ -43,5 +51,25 @@ final class ArrayCollection implements Collection
                 static fn (mixed $existing): bool => $existing !== $element
             )
         );
+    }
+
+    public function map(callable $callback): Collection
+    {
+        return new self(array_map($callback, $this->elements));
+    }
+
+    public function toArray(): array
+    {
+        return $this->elements;
+    }
+
+    public function count(): int
+    {
+        return count($this->elements);
+    }
+
+    public function first(): mixed
+    {
+        return $this->elements[0] ?? false;
     }
 }

--- a/tests/Stubs/FakeObjectRepository.php
+++ b/tests/Stubs/FakeObjectRepository.php
@@ -16,9 +16,34 @@ final class FakeObjectRepository
     public function find(int $id): ?object
     {
         foreach ($this->rows as $row) {
-            if (($row['id'] ?? null) === $id) {
+            if (is_array($row) && ($row['id'] ?? null) === $id) {
                 return (object) $row;
             }
+
+            if (is_object($row) && $this->extractId($row) === $id) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractId(object $entity): ?int
+    {
+        if (method_exists($entity, 'getId')) {
+            $id = $entity->getId();
+
+            return $id !== null ? (int) $id : null;
+        }
+
+        $reflection = new \ReflectionObject($entity);
+        if ($reflection->hasProperty('id')) {
+            $property = $reflection->getProperty('id');
+            $property->setAccessible(true);
+
+            $value = $property->getValue($entity);
+
+            return $value !== null ? (int) $value : null;
         }
 
         return null;


### PR DESCRIPTION
## Summary
- return RobotDanceOff entities from collection queries by adding a fetchResult helper and a RobotDanceOffQueryBuilder::fetch method that extracts the entity from Doctrine results, then have the repository use it
- adjust the Doctrine stubs and fake repositories/collections so they can work with entity datasets and collection helpers that mirror production behavior
- refresh the repository test to build real entities and assert on them, and add a responder unit test that confirms RobotDanceOffResponder maps entity data into its response DTOs
